### PR TITLE
Added h5py==2.6.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,3 +8,4 @@ Theano==0.8.2
 Twisted==16.3.0
 txaio==2.5.1
 zope.interface==4.2.0
+h5py==2.6.0


### PR DESCRIPTION
File "/usr/local/lib/python2.7/dist-packages/keras/utils/io_utils.py", line 3, in <module>
import h5py
ImportError: No module named h5py